### PR TITLE
[RUN-4638] Migrate publishing from Maven Central to PackageCloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      PKGCLD_REPO_URL: ${{ vars.PKGCLD_REPO_URL }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -41,10 +43,36 @@ jobs:
             build/libs/aws-s3-steps-${{ steps.get_version.outputs.VERSION }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to Maven Central
-        run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} -PsonatypeUsername=${SONATYPE_USERNAME} -PsonatypePassword=${SONATYPE_PASSWORD} publishToSonatype closeAndReleaseSonatypeStagingRepository
+      - name: Publish to PackageCloud
+        run: |
+          if [ -z "$PKGCLD_WRITE_TOKEN" ]; then
+            echo "::error::PKGCLD_WRITE_TOKEN must be set to publish to PackageCloud"
+            exit 1
+          fi
+          ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
+      - name: Sign and upload GPG signatures to PackageCloud
+        run: |
+          set -e
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          BASE_URL="${PKGCLD_REPO_URL:-https://packagecloud.io/pagerduty/rundeck-plugins/maven2}/org/rundeck/plugins/aws-s3-steps/${VERSION}"
+
+          echo "$SIGNING_KEY_B64" | base64 -d | gpg --batch --yes --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5; exit}')
+
+          sign_and_upload() {
+            local FILE="$1"
+            local REMOTE_NAME="$2"
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$SIGNING_PASSWORD" --default-key "$KEY_ID" --detach-sign --armor "$FILE"
+            curl -sf -H "Authorization: Bearer ${PKGCLD_WRITE_TOKEN}" \
+              -X PUT --data-binary "@${FILE}.asc" \
+              "${BASE_URL}/${REMOTE_NAME}.asc"
+          }
+
+          sign_and_upload "build/libs/aws-s3-steps-${VERSION}.zip" "aws-s3-steps-${VERSION}.jar"
+          sign_and_upload "build/publications/mavenZip/pom-default.xml" "aws-s3-steps-${VERSION}.pom"
+        env:
           SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
+    id 'base'
     id 'pl.allegro.tech.build.axion-release' version '1.21.2'
-    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 group = 'org.rundeck.plugins'
@@ -96,15 +96,6 @@ pluginZip.doFirst {
     }
 }
 
-nexusPublishing {
-    packageGroup = 'org.rundeck.plugins'
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-        }
-    }
-}
 
 apply from: "${rootDir}/gradle/publishing.gradle"
 

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,9 +1,10 @@
 /**
- * Zip-based Rundeck plugin publication for Maven Central (artifact uploaded as type jar).
+ * Zip-based Rundeck plugin publication (artifact uploaded as type jar).
  * Requires: ext.publishName, ext.githubSlug, ext.developers; task pluginZip
  */
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
+
+def pkgcldRepoUrl = (System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeck-plugins/maven2").trim()
 
 publishing {
     publications {
@@ -49,32 +50,16 @@ publishing {
         }
     }
     repositories {
-        def pkgcldWriteToken = System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken")
-        if (pkgcldWriteToken) {
-            maven {
-                name = "PackageCloudTest"
-                url = uri("https://packagecloud.io/pagerduty/rundeckpro-test/maven2")
-                authentication {
-                    header(HttpHeaderAuthentication)
-                }
-                credentials(HttpHeaderCredentials) {
-                    name = "Authorization"
-                    value = "Bearer " + pkgcldWriteToken
-                }
+        maven {
+            name = "PackageCloud"
+            url = uri(pkgcldRepoUrl)
+            authentication {
+                header(HttpHeaderAuthentication)
+            }
+            credentials(HttpHeaderCredentials) {
+                name = "Authorization"
+                value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
             }
         }
-    }
-}
-
-def base64Decode = { String prop ->
-    project.findProperty(prop) ?
-            new String(Base64.getDecoder().decode(project.findProperty(prop).toString())).trim() :
-            null
-}
-
-if (project.hasProperty('signingKey') && project.hasProperty('signingPassword')) {
-    signing {
-        useInMemoryPgpKeys(base64Decode("signingKey"), project.signingPassword)
-        sign(publishing.publications)
     }
 }


### PR DESCRIPTION
## Jira ticket

[RUN-4638](https://pagerduty.atlassian.net/browse/RUN-4638) (subtask of [RUN-4570](https://pagerduty.atlassian.net/browse/RUN-4570))

## Description

Migrate `aws-s3-steps` publishing from Maven Central (Sonatype) to PackageCloud, applying the same design already validated on [rundeck-plugins/sshj-plugin#136](https://github.com/rundeck-plugins/sshj-plugin/pull/136) and the other already-migrated `rundeck-plugins` repos. Part of the RUN-4570 Maven Central publishing limits resolution — plugins account for the bulk of the file/release count on Maven Central, but no external project depends on them as Maven dependencies.

- Removed `nexusPublish`/`nexusPublishing`. Added `id 'base'` explicitly to the `plugins {}` block — `io.github.gradle-nexus.publish-plugin` was silently providing the `base`/`build`/`assemble`/`check` lifecycle tasks this repo never declared on its own; removing it without adding `base` back broke `./gradlew build` entirely with "Task with name 'build' not found".
- Point the PackageCloud maven repo at the configurable `PKGCLD_REPO_URL` env var (with a fallback to the real `rundeck-plugins` repo), dropping the now-unnecessary guard.
- Dropped Gradle-side GPG signing (`sign(publishing.publications)`): PackageCloud's Maven endpoint rejects the checksum Gradle auto-generates for `.asc` signature files (422 Unprocessable Entity). Sign and upload via `gpg` CLI + `curl` instead, directly in `release.yml` — the same mechanism validated end-to-end on `sshj-plugin`.
- `release.yml`: replaced the "Publish to Maven Central" step with "Publish to PackageCloud" + a "Sign and upload GPG signatures" step.

## Testing instructions

- Merge this PR.
- Tag a version to trigger the release workflow.
- Verify `./gradlew build` still succeeds (this is what the missing `id 'base'` would have broken).
- Verify the artifact and its `.asc` signature land under `org/rundeck/plugins/aws-s3-steps/<version>/` on PackageCloud.
